### PR TITLE
Rectify w/o pre-existing non-rectified images

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,13 +46,12 @@ if __name__ == "__main__":
     t = 10 #Temperature in Celsius
     nchunk = 500 #Number of pings per chunk
     wcp = True #Export tiles with water column present
-    wcr = True #Export Tiles with water column removed
+    src = True #Export Tiles with water column removed/slant range corrected
     detectDepth = False #True==Automatically detect depth; False==Use Humminbird depth
     smthDep = True #Smooth depth before water column removal
 
-    ## In order to rectify, wcp and/or wcr tiles must have been exported (ie wcr=True)
-    rect_wcp = False #Export rectified tiles with water column present
-    rect_wcr = True #Export rectified tiles with water column removed
+    rect_wcp = True #Export rectified tiles with water column present
+    rect_src = True #Export rectified tiles with water column removed/slant range corrected
 
     #==================================================
     t = float(t)/10
@@ -61,16 +60,16 @@ if __name__ == "__main__":
     print('***** READING *****')
     for k in range(len(H)):
         print("working on "+P[k])
-        read_master_func(S[k], H[k], P[k], t, nchunk, wcp, wcr, detectDepth, smthDep)
+        read_master_func(S[k], H[k], P[k], t, nchunk, wcp, src, detectDepth, smthDep)
 
     #==================================================
-    if rect_wcp or rect_wcr:
+    if rect_wcp or rect_src:
         print('\n===========================================')
         print('===========================================')
         print('***** RECTIFYING *****')
         for k in range(len(H)):
             print("working on "+P[k])
-            rectify_master_func(S[k], H[k], P[k], nchunk, rect_wcp, rect_wcr)
+            rectify_master_func(S[k], H[k], P[k], nchunk, detectDepth, smthDep, rect_wcp, rect_src)
 
     keep_going = False
 print("Total Processing Time: ",round((time.time() - start_time),ndigits=2))

--- a/pj_rectify.py
+++ b/pj_rectify.py
@@ -6,7 +6,7 @@ from common_funcs import *
 from c_rectObj import rectObj
 
 #===========================================
-def rectify_master_func(sonFiles, humFile, projDir, nchunk, rect_wcp=False, rect_wcr=False):
+def rectify_master_func(sonFiles, humFile, projDir, nchunk, detectDepth, smthDep, rect_wcp=False, rect_src=False):
     flip = False #Flip port/star
     # filter = 50 #For filtering pings
     filter = int(nchunk*0.1)
@@ -122,8 +122,8 @@ def rectify_master_func(sonFiles, humFile, projDir, nchunk, rect_wcp=False, rect
     if rect_wcp:
         print('\t\tRectifying with Water Column')
         remWater = False
-        Parallel(n_jobs= np.min([len(portstar), cpu_count()]), verbose=10)(delayed(son._rectSon)(remWater, filter, wgs=False) for son in portstar)
-    if rect_wcr:
+        Parallel(n_jobs= np.min([len(portstar), cpu_count()]), verbose=10)(delayed(son._rectSon)(detectDepth, smthDep, remWater, filter, wgs=False) for son in portstar)
+    if rect_src:
         print('\t\tRectifying with Water Column Removed')
         remWater = True
-        Parallel(n_jobs= np.min([len(portstar), cpu_count()]), verbose=10)(delayed(son._rectSon)(remWater, filter, wgs=False) for son in portstar)
+        Parallel(n_jobs= np.min([len(portstar), cpu_count()]), verbose=10)(delayed(son._rectSon)(detectDepth, smthDep, remWater, filter, wgs=False) for son in portstar)


### PR DESCRIPTION
Previous functionality required the export of non-rectified wcp and/or src imagery in order to rectify imagery through setting the following flags to `True` in `main.py`:

```
#################
# User Parameters
t = 10 #Temperature in Celsius
nchunk = 500 #Number of pings per chunk
wcp = True #Export tiles with water column present
src = True #Export Tiles with water column removed/slant range corrected
detectDepth = False #True==Automatically detect depth; False==Use Humminbird depth
smthDep = True #Smooth depth before water column removal

rect_wcp = True #Export rectified tiles with water column present
rect_src = True #Export rectified tiles with water column removed/slant range corrected
```

This is no longer necessary.  Georectified imagery can be exported by setting rect_wcp and/or rect_src to `True` while leaving wcp and src set to `False`:

```
#################
# User Parameters
t = 10 #Temperature in Celsius
nchunk = 500 #Number of pings per chunk
wcp = False #Export tiles with water column present
src = False #Export Tiles with water column removed/slant range corrected
detectDepth = False #True==Automatically detect depth; False==Use Humminbird depth
smthDep = True #Smooth depth before water column removal

rect_wcp = True #Export rectified tiles with water column present
rect_src = True #Export rectified tiles with water column removed/slant range corrected
```