### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ cython_debug/
 .pixi/
 # Pixi lock
 pixi.lock
+
+# Local test and development data
+.data/

--- a/pingmapper/test_PINGMapper.py
+++ b/pingmapper/test_PINGMapper.py
@@ -90,10 +90,12 @@ def test(ds):
         print("1 = Short recording \n2 = Long recording \n\nSYNTAX: python test_PINGMapper.py <1 or 2>\n\n")
         sys.exit()
 
-    d = os.environ.get('PINGMAPPER_DATA_DIR',
-        os.environ.get('CONDA_PREFIX',
-            os.path.join(os.path.expanduser('~'), '.pingmapper')))
-    exampleDir = os.path.join(d, 'exampleData')
+    repo_root = PACKAGE_DIR
+    d = os.environ.get(
+        'PINGMAPPER_DATA_DIR',
+        os.path.join(repo_root, '.data'),
+    )
+    exampleDir = os.path.join(d, 'example_data')
     ds_path = os.path.join(exampleDir, ds_name)
     ds_path = os.path.normpath(ds_path)
 
@@ -120,7 +122,12 @@ def test(ds):
     # Path to data/output
     inFile = ds_path+'.DAT'
     sonPath = ds_path
-    projDir = os.path.join(user_home_path, 'Desktop', 'PINGMapper-'+ds_name)
+    proj_base_dir = os.environ.get(
+        'PINGMAPPER_TEST_OUTPUT_DIR',
+        os.path.join(d, 'test_runs'),
+    )
+
+    projDir = os.path.join(proj_base_dir, 'PINGMapper-'+ds_name)
 
     inFile = os.path.abspath(inFile)
     sonPath = os.path.abspath(sonPath)
@@ -239,7 +246,7 @@ def test(ds):
     if project_mode == 0:
         # Create new project
         if not os.path.exists(projDir):
-            os.mkdir(projDir)
+            os.makedirs(projDir, exist_ok=False)
         else:
             projectMode_1_inval()
 
@@ -248,7 +255,7 @@ def test(ds):
         if os.path.exists(projDir):
             shutil.rmtree(projDir)
 
-        os.mkdir(projDir)        
+        os.makedirs(projDir, exist_ok=False)
 
     elif project_mode == 2:
         # Update project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    { name = "Cameron Bodine", email = "bodine.cs@gmail.email" },
+    { name = "Cameron Bodine"},
     { name = "Daniel Buscombe" },
+    { name = "Iury T Simoes-Sousa"}
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
  ## Summary

  Update the tests to use repo-local data and output paths by default, rather than /Desktop.
  This makes local development and test runs more consistent with the current repo structure.

  ## Changes

  - default test data to `.data/example_data`
  - default test outputs to `.data/test_runs`
  - keep env var overrides for custom locations
  - ignore `.data/` in git
  - clean up `pyproject.toml` author metadata (@CameronBodine, let me know who should be here)



Let's see if this is going to work with CI.
