### PR TITLE
Fix matplotlib>=3.9 compatibility: replace removed plt.cm.get_cmap

### DIFF
--- a/pingmapper/class_mapSubstrateObj.py
+++ b/pingmapper/class_mapSubstrateObj.py
@@ -880,7 +880,7 @@ class mapSubObj(rectObj):
             ax.imshow(son, cmap='gray')
 
             # Prepare color map
-            color_map = plt.cm.get_cmap('viridis')
+            color_map = plt.get_cmap('viridis')
 
             im = ax.imshow(c, cmap=color_map, alpha=0.5, vmin=minSoft, vmax=maxSoft)
             ax.axis('off')

--- a/pingmapper/class_rectObj.py
+++ b/pingmapper/class_rectObj.py
@@ -1968,7 +1968,7 @@ class rectObj(sonObj):
                     use_uint8_rgb = self._export_colormap_as_uint8()
                     if source_scale_bounds is not None:
                         norm_data = self._normalize_with_bounds(sonRect_raw16, source_scale_bounds[0], source_scale_bounds[1])
-                        cmap = plt.cm.get_cmap(self.son_colorMap_name)(norm_data)
+                        cmap = plt.get_cmap(self.son_colorMap_name)(norm_data)
                         if use_uint8_rgb:
                             sonRect_out = np.clip(cmap[:, :, :3] * 255.0, 0, 255).astype(np.uint8)
                         else:
@@ -2769,9 +2769,9 @@ class rectObj(sonObj):
                     if source_scale_bounds is not None:
                         norm_data = self._normalize_with_bounds(out16_raw, source_scale_bounds[0], source_scale_bounds[1])
                         if use_uint8_rgb:
-                            out16 = np.clip(plt.cm.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 255.0, 0, 255).astype(np.uint8)
+                            out16 = np.clip(plt.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 255.0, 0, 255).astype(np.uint8)
                         else:
-                            out16 = np.clip(plt.cm.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 65535.0, 0, 65535).astype(np.uint16)
+                            out16 = np.clip(plt.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 65535.0, 0, 65535).astype(np.uint16)
                         valid_mask = out16_raw > 0
                         out16[valid_mask] = np.maximum(out16[valid_mask], 1)
                     else:
@@ -2914,9 +2914,9 @@ class rectObj(sonObj):
                     if source_scale_bounds is not None:
                         norm_data = self._normalize_with_bounds(out16_raw, source_scale_bounds[0], source_scale_bounds[1])
                         if use_uint8_rgb:
-                            out16 = np.clip(plt.cm.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 255.0, 0, 255).astype(np.uint8)
+                            out16 = np.clip(plt.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 255.0, 0, 255).astype(np.uint8)
                         else:
-                            out16 = np.clip(plt.cm.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 65535.0, 0, 65535).astype(np.uint16)
+                            out16 = np.clip(plt.get_cmap(self.son_colorMap_name)(norm_data)[:, :, :3] * 65535.0, 0, 65535).astype(np.uint16)
                         valid_mask = out16_raw > 0
                         out16[valid_mask] = np.maximum(out16[valid_mask], 1)
                     else:

--- a/pingmapper/class_sonObj.py
+++ b/pingmapper/class_sonObj.py
@@ -1872,7 +1872,7 @@ class sonObj(object):
         return out
 
     def _colorize_array_batched(self, norm_data, valid_mask, cmap_name, scale_max, out_dtype):
-        cmap = plt.cm.get_cmap(cmap_name)
+        cmap = plt.get_cmap(cmap_name)
         height, width = norm_data.shape
         out = np.zeros((height, width, 3), dtype=out_dtype)
 

--- a/pingmapper/class_sonObj_nadirgaptest.py
+++ b/pingmapper/class_sonObj_nadirgaptest.py
@@ -1500,7 +1500,7 @@ class sonObj(object):
             # plt.savefig(outfile)
 
             norm_data = data / 255.0
-            colored_data = plt.cm.get_cmap(self.sonogram_colorMap)(norm_data)
+            colored_data = plt.get_cmap(self.sonogram_colorMap)(norm_data)
             colored_data = (colored_data[:, :, :3] * 255).astype('uint8')
             data = colored_data
 


### PR DESCRIPTION
## Summary

Fixes #203.

On matplotlib **3.9+**, running the test dataset (`python -m pingmapper test`) crashes during sonogram tile export with:

```
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
```

`matplotlib.cm.get_cmap` was **deprecated in matplotlib 3.7 and removed in 3.9**. PINGMapper calls it as `plt.cm.get_cmap(...)` in several colormap paths, so any environment with a current matplotlib (reproduced here on **3.11**) fails as soon as it reaches sonogram/rectified-tile colorizing.

## Fix

Replace every `plt.cm.get_cmap(...)` with the still-supported **`plt.get_cmap(...)`** (`matplotlib.pyplot.get_cmap`). This is a minimal drop-in: it returns the same `Colormap` object, is not deprecated in current matplotlib, and — like the old API — gracefully handles a `None` colormap name. The already-valid `matplotlib.colormaps.get_cmap(...)` calls in `class_rectObj.py` are left untouched.

| File | Call sites fixed |
|------|-----------------|
| `pingmapper/class_sonObj.py` | 1 (`_colorize_array_batched`, the crash in #203) |
| `pingmapper/class_rectObj.py` | 5 (rectified GeoTiff colormap paths) |
| `pingmapper/class_mapSubstrateObj.py` | 1 (substrate summary plot) |
| `pingmapper/class_sonObj_nadirgaptest.py` | 1 |

## Testing

Ran `python -m pingmapper test` (small dataset) on **matplotlib 3.11** — the full **read → rectify → substrate** pipeline now runs to completion, including the previously-failing *"Exporting sonogram tiles"* stage.

<details>
<summary>Why <code>plt.get_cmap</code> rather than <code>matplotlib.colormaps[name]</code></summary>

Both work, but `plt.get_cmap(name)` is the smallest possible change from `plt.cm.get_cmap(name)` (just drop `.cm`), keeps the exact same call signature, and preserves the old behavior of accepting `None` (returns the default colormap) — whereas `matplotlib.colormaps[None]` raises `KeyError`. `plt` is already imported in every affected module, so no import changes are needed. It also matches the existing `colormaps.get_cmap(...)` usage already present in `class_rectObj.py`.

</details>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
